### PR TITLE
#13 Abort if Make version is unsupported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         PATH="/usr/local/bin:$PATH" make test
 
     - name: jammy (22.04)
-      if: commit_message =~ /\!jammy/
+      if: commit_message =~ /build\!jammy/
       os: linux
       dist: jammy
       install: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
         PATH="/usr/local/bin:$PATH" make test
 
     - name: jammy (22.04)
+      if: commit_message =~ /\!jammy/
       os: linux
       dist: jammy
       install: >-
@@ -34,7 +35,7 @@ jobs:
     # Only run for the main branch.
     # Travis OSX jobs are 5x more expensive than Linux ones.
     - name: osx xcode12
-      if: commit_message =~ /!osx/
+      if: branch = main
       os: osx
       osx_image: xcode12
       before_install: brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
     # Only run for the main branch.
     # Travis OSX jobs are 5x more expensive than Linux ones.
     - name: osx xcode12
-      if: branch = main
+      if: commit_message =~ /!osx/
       os: osx
       osx_image: xcode12
       before_install: brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
         PATH="/usr/local/bin:$PATH" make test
 
     - name: jammy (22.04)
-      if: commit_message =~ /build\!jammy/
       os: linux
       dist: jammy
       install: >-
@@ -35,7 +34,7 @@ jobs:
     # Only run for the main branch.
     # Travis OSX jobs are 5x more expensive than Linux ones.
     - name: osx xcode12
-      if: branch = main
+      if: commit_message =~ /build\!osx/
       os: osx
       osx_image: xcode12
       before_install: brew update

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ SHELL := /usr/bin/env bash -e -o pipefail
 ####################################################################################################
 
 NAME := bmakelib
-ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DIST := $(ROOT)dist/
 VERSION := $(file < $(ROOT)src/VERSION)
+
+####################################################################################################
+
+include src/bmakelib.Makefile
 
 ####################################################################################################
 

--- a/src/bmakelib.Makefile
+++ b/src/bmakelib.Makefile
@@ -1,0 +1,69 @@
+# Copyright © 2023 Bahman Movaqar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################################
+
+####################################################################################################
+# Minimum Make version supported.
+# Anything older either breaks bmakelib or can cause it to behave in unexpected ways.
+####################################################################################################
+
+bmakelib.MIN_MAKE_VERSION := 4.4
+
+####################################################################################################
+# Abort with a, hopefully, informative message if it's an unsupported Make version.
+####################################################################################################
+
+ifeq ($(shell perl -E 'print $$1 if "$(MAKE_VERSION)" =~ /^\s*(\d+(\.\d+)?)/ && $$1 >= $(bmakelib.MIN_MAKE_VERSION)'),)
+
+# Expands to a newline
+define bmakelib.newline
+
+
+endef
+
+# Expands to 8 consequtive spaces
+bmakelib.octospace := $(subst ,        ,)
+
+# Expands to a backslash
+bmakelib.backslash := $(subst ,\,)
+
+# Abort
+$(error \
+Incompatible Make version.$(bmakelib.newline)\
+The minimum Make version supported by bmakelib is $(bmakelib.MIN_MAKE_VERSION) while you are $(bmakelib.newline)\
+running $(MAKE_VERSION).$(bmakelib.newline)$(bmakelib.newline)\
+\
+bmakelib has aborted the make process in order to avoid unexpected$(bmakelib.newline)\
+behaviours and hard to find bugs.$(bmakelib.newline)$(bmakelib.newline)\
+\
+Please either remove your dependency on bmakelib or upgrade to a more$(bmakelib.newline)\
+modern Make.  On most platforms, upgrading is as simple as running $(bmakelib.newline)$(bmakelib.newline)\
+\
+\
+$(bmakelib.octospace)wget 'https://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz' $(bmakelib.backslash)$(bmakelib.newline) \
+$(bmakelib.octospace)&& tar xzf make-4.4.1.tar.gz                          $(bmakelib.backslash)$(bmakelib.newline) \
+$(bmakelib.octospace)&& cd make-4.4.1                                      $(bmakelib.backslash)$(bmakelib.newline) \
+$(bmakelib.octospace)&& ./configure --prefix=/usr/local                    $(bmakelib.backslash)$(bmakelib.newline) \
+$(bmakelib.octospace)&& sudo make install$(bmakelib.newline)$(bmakelib.newline))
+
+endif
+
+####################################################################################################
+# If it's a supported Make version, include the rest of the bmakelib suite.
+####################################################################################################
+
+export bmakelib.ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+include $(bmakelib.ROOT)/error-if-blank.Makefile
+include $(bmakelib.ROOT)/default-if-blank.Makefile

--- a/tests/test_default-if-blank
+++ b/tests/test_default-if-blank
@@ -28,7 +28,7 @@ function use_default_when_blank {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/default-if-blank.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-var1
 
@@ -59,7 +59,7 @@ function ignore_default_when_nonblank {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/default-if-blank.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-var1
 
@@ -90,7 +90,7 @@ function multiple_variable_value_pairs {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/default-if-blank.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-vars
 
@@ -121,7 +121,7 @@ function emit_info_when_not_SILENT {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/default-if-blank.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-vars
 

--- a/tests/test_error-if-blank
+++ b/tests/test_error-if-blank
@@ -28,7 +28,8 @@ function single_var_exit_when_blank {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/error-if-blank.Makefile
+#include ${BMAKELIB_ROOT}/bmakelib.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-var1
 
@@ -58,7 +59,7 @@ function multi_var_exist_on_first_nonblank {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/error-if-blank.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-vars
 
@@ -88,7 +89,7 @@ function ok_all_nonblank_vars {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-include ${root_dir}/src/error-if-blank.Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-vars
 


### PR DESCRIPTION
Abort make with an informative message if the Make version in use is not supported.  Currently the minimum required is 4.4.