### PR TITLE
Implement `bmakelib.timed`

### DIFF
--- a/src/bmakelib.Makefile
+++ b/src/bmakelib.Makefile
@@ -14,14 +14,14 @@
 ####################################################################################################
 
 ####################################################################################################
-# Minimum Make version supported.
-# Anything older either breaks bmakelib or can cause it to behave in unexpected ways.
+#   Minimum Make version supported.
+#   Anything older either breaks bmakelib or can cause it to behave in unexpected ways.
 ####################################################################################################
 
 bmakelib.MIN_MAKE_VERSION := 4.4
 
 ####################################################################################################
-# Abort with a, hopefully, informative message if it's an unsupported Make version.
+#   Abort with, hopefully, an informative message if it's an unsupported Make version.
 ####################################################################################################
 
 ifeq ($(shell perl -E 'print $$1 if "$(MAKE_VERSION)" =~ /^\s*(\d+(\.\d+)?)/ && $$1 >= $(bmakelib.MIN_MAKE_VERSION)'),)
@@ -60,10 +60,11 @@ $(bmakelib.octospace)&& sudo make install$(bmakelib.newline)$(bmakelib.newline))
 endif
 
 ####################################################################################################
-# If it's a supported Make version, include the rest of the bmakelib suite.
+#   If it's a supported Make version, include the rest of the bmakelib suite.
 ####################################################################################################
 
 export bmakelib.ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 include $(bmakelib.ROOT)/error-if-blank.Makefile
 include $(bmakelib.ROOT)/default-if-blank.Makefile
+include $(bmakelib.ROOT)/timed.Makefile

--- a/src/timed.Makefile
+++ b/src/timed.Makefile
@@ -66,7 +66,7 @@
 	     $(info Target '$(*)' took $(bmakelib.vars.timed.duration.$(*))ms to complete.))
 
 ####################################################################################################
-#   Wether to define the convenience target %!timed.
+#   Whether to define the convenience target %!timed.
 #   Set to 'no' *before* including bmakelib to disable.
 ####################################################################################################
 

--- a/src/timed.Makefile
+++ b/src/timed.Makefile
@@ -1,0 +1,128 @@
+# Copyright © 2023 Bahman Movaqar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################################
+
+####################################################################################################
+#   # %!bmakelib.timed
+#
+#   Times the execution of a given target and report the duration with milliseconds precision.
+#   The following variables will be populated:
+#     * stdlib.vars.timed.begin-ts.TARGET_NAME (nanos)
+#     * stdlib.vars.timed.end-ts.TARGET_NAME (nanos)
+#     * stdlib.vars.timed.duration.TARGET_NAME (millis)
+#
+#   # Example 1
+#
+#   Makefile:
+#       ```
+#       my-target :
+#       	@sleep 2
+#       	@echo my-target is done
+#       ```
+#
+#   Shell:
+#       ```
+#       $ make my-target!bmakelib.timed
+#       Using default value 'yes' for variable 'stdlib.conf.timed.SILENT'
+#       my-target is done
+#       Target 'my-target' took 2009ms to complete.
+#       ```
+#
+#   # Example 2
+#
+#   Makefile:
+#       ```
+#       some-target :
+#       	@sleep 2
+#
+#       my-target : stdlib.conf.timed.SILENT = yes
+#       my-target : some-target!bmakelib.timed
+#       	@echo ✅ Made some-target in $(stdlib.vars.timed.duration.some-target)ms 🙌
+#       ```
+#
+#   Shell:
+#        ```
+#        $ make my-target
+#        ✅ Made some-target in 2008ms 🙌
+#        ```
+####################################################################################################
+
+.PHONY : %!bmakelib.timed
+
+%!bmakelib.timed : bmakelib.default-if-blank( bmakelib.conf.timed.SILENT,no ) bmakelib._%!timed
+	$(if $(filter yes,$(bmakelib.conf.timed.SILENT)), \
+	     , \
+	     $(info Target '$(*)' took $(bmakelib.vars.timed.duration.$(*))ms to complete.))
+
+####################################################################################################
+#   Wether to define the convenience target %!timed.
+#   Set to 'no' *before* including bmakelib to disable.
+####################################################################################################
+
+bmakelib.conf.timed.convenience-target ?= yes
+
+####################################################################################################
+#   Convenice target with a shorter and more intuitive name.  It's a drop-in replacement for
+#   %!bmakelib.timed.
+#
+#   Lets you write
+#       ```
+#       some-target : other-target!timed
+#       ```
+#   or
+#       ```
+#       $ make my-target!timed
+#       ```
+#
+#   See also bmakelib.conf.timed.convenience-target
+####################################################################################################
+
+ifneq ($(bmakelib.conf.timed.convenience-target),no)
+
+.PHONY : %!timed
+
+%!timed : %!bmakelib.timed ;
+
+endif
+
+####################################################################################################
+#   Steps to take before executing the given target
+####################################################################################################
+
+.PHONY : bmakelib._%!timed-pre
+.NOTINTERMEDIATE : bmakelib._%!timed-pre
+
+bmakelib._%!timed-pre :
+	$(eval bmakelib.vars.timed.begin-ts.$(*) := $(shell date +%s%N))
+
+####################################################################################################
+#   Steps to take after executing the given target
+####################################################################################################
+
+.PHONY : bmakelib._%!timed-post
+.NOTINTERMEDIATE : bmakelib._%!timed-post
+
+bmakelib._%!timed-post :
+	$(eval bmakelib.vars.timed.end-ts.$(*) := $(shell date +%s%N))
+
+####################################################################################################
+#   Execute the given target and measure the duration
+####################################################################################################
+
+.PHONY : bmakelib._%!timed
+.NOTINTERMEDIATE : bmakelib._%!timed
+
+bmakelib._%!timed : bmakelib._%!timed-pre .WAIT % .WAIT bmakelib._%!timed-post
+	$(eval bmakelib.vars.timed.duration.$(*) := \
+		$(shell echo $$(( ($(bmakelib.vars.timed.end-ts.$(*)) - $(bmakelib.vars.timed.begin-ts.$(*))) / 1000000))))

--- a/tests/test_error-if-blank
+++ b/tests/test_error-if-blank
@@ -28,7 +28,6 @@ function single_var_exit_when_blank {
   local test_case_name=${FUNCNAME[0]}
   local actual_value_filename=${test_case_name}.actual.log
   bmakelib.test.cat <<EOF > Makefile
-#include ${BMAKELIB_ROOT}/bmakelib.Makefile
 include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
 
 .PHONY : echo-var1

--- a/tests/test_timed
+++ b/tests/test_timed
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+####################################################################################################
+# Copyright © 2023 Bahman Movaqar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################################
+
+set -o pipefail
+
+test_suite_name=$(basename $BASH_SOURCE)
+source ${root_dir}tests/lib.sh
+
+####################################################################################################
+# emit an info with time the given target took to execute when timed is an implicit prerequisite.
+####################################################################################################
+
+function ok_emit_info_with_duration_implicit_prerequisite {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
+
+.PHONY : some-target
+
+some-target :
+	@echo Running some-target with implicit timed prereq...
+EOF
+
+  make some-target!timed > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+Running some-target with implicit timed prereq...
+Target 'some-target' took (?<duration>\d+)ms to complete.
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# emit an info with time the given target took to execute when timed is an explicit prerequisite.
+####################################################################################################
+
+function ok_emit_info_with_duration_explicit_prerequisite {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
+
+.PHONY : do-some-target
+
+do-some-target :
+	@echo Running do-some-target with explicit timed prereq...
+
+.PHONY : some-target
+
+some-target : do-some-target!timed
+EOF
+
+  make some-target > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+Running do-some-target with explicit timed prereq...
+Target 'do-some-target' took (?<duration>\d+)ms to complete.
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# do not emit any additional output if SILENT is set
+####################################################################################################
+
+function ok_no_additional_output_if_silent {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
+
+.PHONY : some-target
+
+some-target :
+	@echo Running some-target...
+EOF
+
+  make bmakelib.conf.timed.SILENT=yes some-target!timed > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+Running some-target...
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# emit an info with time the given target took to execute when timed is an implicit prerequisite.
+####################################################################################################
+
+function ok_emit_info_when_convenience_target_is_disabled {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+bmakelib.conf.timed.convenience-target := no
+
+include $( perl -E 'print $ENV{"bmakelib.ROOT"}' )/bmakelib.Makefile
+
+.PHONY : some-target
+
+some-target :
+	@echo Running some-target with implicit timed prereq...
+EOF
+
+  make some-target!bmakelib.timed > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+Running some-target with implicit timed prereq...
+Target 'some-target' took (?<duration>\d+)ms to complete.
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+
+test_cases=( ok_emit_info_with_duration_implicit_prerequisite \
+               ok_emit_info_with_duration_explicit_prerequisite \
+               ok_no_additional_output_if_silent \
+               ok_emit_info_when_convenience_target_is_disabled )
+
+test_case_name=''	# mutated in the for loop
+test_suite_status=0	# mutated in the for loop
+for test_case in ${test_cases[@]}; do
+  test_case_name=$test_case
+  if ! bmakelib.test.run_test_case $test_case; then
+    test_suite_status=1
+  fi
+done
+
+exit $test_suite_status


### PR DESCRIPTION
# `%!bmakelib.timed` and `%!timed`                                                                         
                                                                                          
Times the execution of a given target and report the duration with milliseconds precision.  

The following variables will be populated:                                                
  * `stdlib.vars.timed.begin-ts.TARGET_NAME` (nanos)                                        
  * `stdlib.vars.timed.end-ts.TARGET_NAME` (nanos)                                          
  * `stdlib.vars.timed.duration.TARGET_NAME` (millis)                                       

# Notes:
The variable `bmakelib.conf.timed.conveniece-target` which defaults to `yes`, controls whether the convenience/shorter target `%!timed` is defined.
        
# Examples                                                                                  

## Example 1                                                                               
                                                                                          
Makefile:                                                                                 
```Makefile                                                                                
my-target :                                                                           
	@sleep 2                                                                      
	@echo my-target is done                                                       
```                                                                                   
                                                                                          
Shell:                                                                                    
```                                                                                   
$ make my-target!timed                                                       
Using default value 'yes' for variable 'stdlib.conf.timed.SILENT'                     
my-target is done                                                                     
Target 'my-target' took 2009ms to complete.                                           
```                                                                                   
                                                                                          
## Example 2                                                                               
                                                                                          
Makefile:                                                                                 
```Makefile                                                                                   
some-target :                                                                         
	@sleep 2                                                                      
                                                                                          
my-target : stdlib.conf.timed.SILENT = yes                                            
my-target : some-target!timed                                                
	@echo ✅ Made some-target in $(stdlib.vars.timed.duration.some-target)ms 🙌   
```                                                                                   
                                                                                          
Shell:                                                                                    
```                                                                                  
$ make my-target                                                                     
✅ Made some-target in 2008ms 🙌                                                     
```                                                                                  