### PR TITLE
Assert against a more flexible path to make

### DIFF
--- a/tests/test_logged
+++ b/tests/test_logged
@@ -49,7 +49,7 @@ Logging target some-target to .+
 exec .+ \\
 \s*&& trap .+ \\
 \s*&& exec .+ \\
-\s*&& make -f .+ some-target
+\s*&& .*make -f .+ some-target
 make.+Leaving.+
 EOF
 
@@ -150,7 +150,7 @@ make.+Entering.+
 \s*exec .+ \\
 \s*&& trap .+ \\
 \s*&& exec .+ \\
-\s*&& make -f .+ some-target
+\s*&& .*make -f .+ some-target
 make.+Leaving.+
 EOF
 
@@ -256,7 +256,7 @@ Logging target target-to-log to .+
 \s*exec .+ \\
 \s*&& trap .+ \\
 \s*&& exec .+ \\
-\s*&& make -f .+ target-to-log
+\s*&& .*make -f .+ target-to-log
 Running some-target with explicitly logged prereq...
 make.+Leaving.+
 EOF

--- a/tests/test_logged_and_timed_chained
+++ b/tests/test_logged_and_timed_chained
@@ -49,7 +49,7 @@ Logging target some-target to .+
 exec .+ \\
 \s*&& trap .+ \\
 \s*&& exec .+ \\
-\s*&& make -f .+ some-target
+\s*&& .*make -f .+ some-target
 Target 'some-target!!logged' took (?<duration>\d+)ms to complete.
 make.+Leaving.+
 EOF
@@ -103,7 +103,7 @@ Logging target some-target!timed to .+
 exec .+ \\
 \s*&& trap .+ \\
 \s*&& exec .+ \\
-\s*&& make -f .+ some-target!timed
+\s*&& .*make -f .+ some-target!timed
 make.+Leaving.+
 EOF
 


### PR DESCRIPTION
on most (all?) linux systems, make is going to be always invoked as `make`.  however this may not hold true if one is using homebrew for example which during formula tests invokes make w/ its absolute path.