### PR TITLE
Use Focal  wherever possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
     - <<: *linux
       name: Build DEB and RPM packages
       os: linux
-      dist: jammy
+      dist: focal
       script: >-
         make package-rpm package-deb
 
@@ -74,7 +74,7 @@ jobs:
 
     - name: Create github release
       os: linux
-      dist: jammy
+      dist: focal
       before_deploy: >-
         [[ -z "$BMAKELIB_VERSION" ]] && export BMAKELIB_VERSION="$(<src/VERSION)"
       deploy:


### PR DESCRIPTION
> would you be able to try with "dist:focal"? It's worth noting that "dist: focal" is generally considered to provide better stability compared to "dist: jammy".

As recommended by Travis for best stability.

Hopefully this resolves the broken release pipeline.