### PR TITLE
Set the ownership of the `_build` directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ jobs:
 
     - <<: *linux
       name: Build & Release
+      if: (branch = master) OR (commit_message =~ /\!build/)
       dist: focal
       script: >-
         make package-rpm package-deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ jobs:
 
     - <<: *linux
       name: Jammy (22.04)
-      os: linux
       dist: jammy
 
     # Only run for the main branch.
@@ -60,12 +59,12 @@ jobs:
     - stage: build & deploy
 
     - <<: *linux
-      name: build & deploy
-      os: linux
+      name: Build & Release
       dist: focal
-      if: (branch = master) OR (tag IS present) OR (commit_message =~ /\!build/)
       script: >-
         make package-rpm package-deb
+      after_script: >-
+        sudo chown -R ${USER} _build
       before_deploy: >-
         [[ -z ${BMAKELIB_VERSION} ]] && export BMAKELIB_VERSION=$(<src/VERSION)
       deploy:
@@ -79,6 +78,6 @@ jobs:
           secure: "ilFr/G75yFMYV5tNDEbt9xtGWoB1tWZdYh4oiGpx20TxK283NW3MJ/cZxQLTs1fBRe8DYRLiAzYdTfdLzjtKyCUfKkTaBCOIs4kKRphd3Od4iNI42AgA6hyT8edeCsyDd0uTui+ZDi7Z2rGCW29PDvWh67GZ31ksTl5bWj+gWtU0Hc+KnBBFGQ+N9U1aC1l7SYnKnGzPrtguoEDKBVoA5lURLc/dmoA51ACV921lJwSALsHwTqSVpW5cS+1xnTOXaFDsm6ebjG8mygzLBv6D54/GnYnpEBt+NhoXtHRP2Q+fWLqlxEDyj8xP8/eE5o/okl1LMz1d8fthYHh6duBT0O8GL6TMlMZAJClTYMPuFbLSyNkHynHjdztGZHZPsTX8zJoizPNVbZE+pr5eydaY6y6Uzp0wJGxb+dNrGfuc0EaPGHb904i32PqSb/AeAFrVHUXTvFlu8zIURe5AcegthCZUAULzAxLcpMX31/yicbNyKph4q7MktzWsYWJ8wuAsCjOLS9yaSkQM7jbTzsG+Xaz2KrQtL52//pLMCYzMPHOxrrtRiCVEhRmQ5K4Z8020yfYPEzOSedZHN1ySIvhLgoCEWRETA9/PGXTa+1JthHNjkciO5e3FPyYu+Lze1UGYO4S4JEwMpH50tJber1sm3PYuYUu5W6EQBL4ORns9b/s="
         file_glob: true
         file:
-          - dist/bmakelib-*.tar.gz
-          - dist/bmakelib-*.noarch.rpm
-          - dist/bmakelib_*_all.deb
+          - "dist/bmakelib-${BMAKELIB_VERSION}.tar.gz"
+          - "dist/bmakelib-${BMAKELIB_VERSION}-*.noarch.rpm"
+          - "dist/bmakelib_${BMAKELIB_VERSION}-*_all.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
+# Copyright © 2023 Bahman Movaqar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################################
+
 ---
 language: shell
 


### PR DESCRIPTION
Since RPM & DEB packages are built in docker (volume), the ownership of the `_build` directory is set to `root` which prevents Travis from cleaning up (stashing) the working copy.