### PR TITLE
fix the directory permissions in `before_deploy`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,10 +79,9 @@ jobs:
       dist: focal
       script: >-
         make package-rpm package-deb
-      after_script: >-
-        sudo chown -R ${USER} _build
       before_deploy: >-
         [[ -z ${BMAKELIB_VERSION} ]] && export BMAKELIB_VERSION=$(<src/VERSION)
+        ; sudo chown -R ${USER} _build
       deploy:
         provider: releases
         draft: true


### PR DESCRIPTION
`after_script` is only run after the deploy stage