### PR TITLE
Implement a fail-fast `$(shell)`

### DIFF
--- a/doc/bmakelib.md
+++ b/doc/bmakelib.md
@@ -36,4 +36,13 @@ Expands to a whitespace
 
 ---
 
+# `⬛`
+
+Expands to an empty string.
+
+This silly-looking variable is a formatting convenience for cases when whitespace is significant
+and will affect the evaluation. See `bmakelib.shell.error-if-nonzero` for an example.
+
+---
+
 

--- a/doc/shell.md
+++ b/doc/shell.md
@@ -1,0 +1,99 @@
+# `bmakelib.shell.error-if-nonzero`
+
+Executes the given shell command and expands the output.  If the command fails with any non-zero
+code, fails the Make process with an "error" message.
+
+###  Example 1
+
+Makefile:
+
+```Makefile
+     VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)
+
+     some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero, echo Hello, world)
+     some-target :
+	@echo Unreachable recipe ⛔
+```
+
+Shell:
+
+```text
+$ make some-target
+Makefile:4: *** bmakelib.shell.error-if-nonzero: Command exited with non-zero value 1.  Stop.
+```
+
+###  Example 2
+
+Makefile:
+
+```Makefile
+VAR1 := $(call bmakelib.shell.error-if-nonzero,\
+	       echo 🧑 $$$$(whoami) 💻 $$$$(perl -nE'say $$$$1 if /^ID="(.+)"$$$$/' < /etc/os-release))
+
+some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero,emacs --version | head -n 1)
+some-target :
+	@echo VAR1=$(VAR1)
+	@echo VAR2=$(VAR2)
+```
+
+Shell:
+
+```text
+$ make some-target
+👉 VAR1=🧑 bahman 💻 opensuse-tumbleweed
+👉 VAR2=GNU Emacs 29.1
+```
+
+###  Example 3
+
+Makefile:
+
+```Makefile
+VAR1 := $(call bmakelib.shell.error-if-nonzero,\
+               docker run --rm ubuntu:22.04 echo Hello, world. && echo Goodbye, world.)
+
+some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero,\
+                             [[ ! -z $$$$JAVA_HOME ]] \
+			     && ls $$$$JAVA_HOME/bin/java \
+			     || echo JAVA_HOME not set.)
+some-target :
+	@echo 👉 VAR1=$(VAR1)
+	@echo 👉 VAR2=$(VAR2)
+```
+
+Shell:
+
+```text
+$ make some-target
+👉 VAR1=Hello, world. Goodbye, world.
+👉 VAR2=/home/bahman/.sdkman/candidates/java/current/bin/java
+```
+
+### Notes:
+
+* Set `bmakelib.conf.shell.error-if-nonzero.SILENT` to "no" to emit an `info` message before
+ running the command.
+
+* Quad-quote all the variables and structures that are supposed to be only understood by shell.
+  For example:
+  - `$(call bmakelib.shell.error-if-nonzero,echo $$$$HOSTNAME)`
+  - `$(call bmakelib.shell.error-if-nonzero,PATH="/usr/local/foo/bin:$$$$PATH" foo $$$$(date))
+
+* Currently the a command can contain upto **9** comma (,) charaters.
+  - This number is totally arbitrary and it can be increased if there's need for it.
+  - Since `$(call)` treats "," (comma) as the parameter separator, it swallows all commas in the
+    commands you pass to `bmakelib.shell.error-if-nonzero`.  This means that those commans need
+    to be manually inserted in the command string.
+
+---
+
+# `bmakelib.conf.shell.error-if-nonzero.SILENT`
+
+Controls whether `bmakelib.shell.error-if-nonzero` should emit an info message before running
+the command.
+
+Default is "yes" which means do NOT emit.  Set to "no" to make it behave otherwise.
+
+---
+
+

--- a/doc/shell.md
+++ b/doc/shell.md
@@ -8,10 +8,10 @@ code, fails the Make process with an "error" message.
 Makefile:
 
 ```Makefile
-     VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)
+VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)
 
-     some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero, echo Hello, world)
-     some-target :
+some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero, echo Hello, world)
+some-target :
 	@echo Unreachable recipe ⛔
 ```
 
@@ -77,7 +77,7 @@ $ make some-target
 * Quad-quote all the variables and structures that are supposed to be only understood by shell.
   For example:
   - `$(call bmakelib.shell.error-if-nonzero,echo $$$$HOSTNAME)`
-  - `$(call bmakelib.shell.error-if-nonzero,PATH="/usr/local/foo/bin:$$$$PATH" foo $$$$(date))
+  - `$(call bmakelib.shell.error-if-nonzero,PATH="/usr/local/foo/bin:$$$$PATH" foo $$$$(date))`
 
 * Currently the a command can contain upto **9** comma (,) charaters.
   - This number is totally arbitrary and it can be increased if there's need for it.

--- a/src/bmakelib.mk
+++ b/src/bmakelib.mk
@@ -79,6 +79,19 @@ bmakelib.backslash := $(subst ,\,)
 bmakelib.space := $(subst , ,)
 
 ####################################################################################################
+#>
+#   # `⬛`
+#
+#   Expands to an empty string.
+#
+#   This silly-looking variable is a formatting convenience for cases when whitespace is significant
+#   and will affect the evaluation. See `bmakelib.shell.error-if-nonzero` for an example.
+#<
+####################################################################################################
+
+⬛ :=
+
+####################################################################################################
 #   Abort with, hopefully, an informative message if it's an unsupported Make version.
 ####################################################################################################
 
@@ -117,7 +130,7 @@ export bmakelib.VERSION := $(file < $(bmakelib.ROOT)VERSION)
 
 ####################################################################################################
 
-bmakelib.FEATURES := error-if-blank.mk default-if-blank.mk timed.mk logged.mk enum.mk
+bmakelib.FEATURES := error-if-blank.mk default-if-blank.mk timed.mk logged.mk enum.mk shell.mk
 
 .PHONY : $(bmakelib.FEATURES:%=$(bmakelib.ROOT)%)
 

--- a/src/shell.mk
+++ b/src/shell.mk
@@ -1,0 +1,124 @@
+# Copyright © 2023 Bahman Movaqar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################################
+
+####################################################################################################
+#>
+#   # `bmakelib.shell.error-if-nonzero`
+#
+#   Executes the given shell command and expands the output.  If the command fails with any non-zero
+#   code, fails the Make process with an "error" message.
+#
+#   ###  Example 1
+#
+#   Makefile:
+#
+#	```Makefile
+#        VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)
+#
+#        some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero, echo Hello, world)
+#        some-target :
+#		@echo Unreachable recipe ⛔
+#	```
+#
+#   Shell:
+#
+#	```text
+#	$ make some-target
+#	Makefile:4: *** bmakelib.shell.error-if-nonzero: Command exited with non-zero value 1.  Stop.
+#	```
+#
+#   ###  Example 2
+#
+#   Makefile:
+#
+#	```Makefile
+#	VAR1 := $(call bmakelib.shell.error-if-nonzero,\
+#		       echo 🧑 $$$$(whoami) 💻 $$$$(perl -nE'say $$$$1 if /^ID="(.+)"$$$$/' < /etc/os-release))
+#
+#	some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero,emacs --version | head -n 1)
+#	some-target :
+#		@echo VAR1=$(VAR1)
+#		@echo VAR2=$(VAR2)
+#	```
+#
+#   Shell:
+#
+#	```text
+#	$ make some-target
+#	👉 VAR1=🧑 bahman 💻 opensuse-tumbleweed
+#	👉 VAR2=GNU Emacs 29.1
+#	```
+#
+#   ###  Example 3
+#
+#   Makefile:
+#
+#	```Makefile
+#	VAR1 := $(call bmakelib.shell.error-if-nonzero,\
+#	               docker run --rm ubuntu:22.04 echo Hello, world. && echo Goodbye, world.)
+#
+#	some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero,\
+#	                             [[ ! -z $$$$JAVA_HOME ]] \
+#				     && ls $$$$JAVA_HOME/bin/java \
+#				     || echo JAVA_HOME not set.)
+#	some-target :
+#		@echo 👉 VAR1=$(VAR1)
+#		@echo 👉 VAR2=$(VAR2)
+#	```
+#
+#   Shell:
+#
+#	```text
+#	$ make some-target
+#	👉 VAR1=Hello, world. Goodbye, world.
+#	👉 VAR2=/home/bahman/.sdkman/candidates/java/current/bin/java
+#	```
+#
+#   ### Notes:
+#
+#   * Set `bmakelib.conf.shell.error-if-nonzero.SILENT` to "no" to emit an `info` message before
+#    running the command.
+#
+#   * Quad-quote all the variables and structures that are supposed to be only understood by shell.
+#     For example:
+#     - `$(call bmakelib.shell.error-if-nonzero,echo $$$$HOSTNAME)`
+#     - `$(call bmakelib.shell.error-if-nonzero,PATH="/usr/local/foo/bin:$$$$PATH" foo $$$$(date))
+#
+#   * Currently the a command can contain upto **9** comma (,) charaters.
+#     - This number is totally arbitrary and it can be increased if there's need for it.
+#     - Since `$(call)` treats "," (comma) as the parameter separator, it swallows all commas in the
+#       commands you pass to `bmakelib.shell.error-if-nonzero`.  This means that those commans need
+#       to be manually inserted in the command string.
+#<
+####################################################################################################
+
+⬛ :=
+
+define bmakelib.shell.error-if-nonzero
+$(eval bmakelib.shell.error-if-nonzero.__command := $(if $(1),$(1)$(if $(2),$(bmakelib.comma)$(2)$(if $(3),$(bmakelib.comma)$(3)$(if $(4),$(bmakelib.comma)$(4)$(if $(5),$(bmakelib.comma)$(5)$(if $(6),$(bmakelib.comma)$(6)$(if $(7),$(bmakelib.comma)$(7)$(if $(8),$(bmakelib.comma)$(8)$(if $(9),$(bmakelib.comma)$(9)$(if $(10),$(bmakelib.comma)$(10),),),),),),),),),),))$(⬛)$(if $(filter yes,$(bmakelib.conf.shell.error-if-nonzero.SILENT)),,$(info shell.error-if-nonzero: $(bmakelib.shell.error-if-nonzero.__command)))$(⬛)$(eval bmakelib.shell.error-if-nonzero.__result := $(shell $(bmakelib.shell.error-if-nonzero.__command)))$(⬛)$(if $(filter-out 0,$(.SHELLSTATUS)),$(error shell.error-if-nonzero: Command exited with non-zero value $(.SHELLSTATUS)),$(bmakelib.shell.error-if-nonzero.__result))
+endef
+
+####################################################################################################
+#>
+#   # `bmakelib.conf.shell.error-if-nonzero.SILENT`
+#
+#   Controls whether `bmakelib.shell.error-if-nonzero` should emit an info message before running
+#   the command.
+#
+#   Default is "yes" which means do NOT emit.  Set to "no" to make it behave otherwise.
+#<
+####################################################################################################
+
+bmakelib.conf.shell.error-if-nonzero.SILENT ?= yes

--- a/src/shell.mk
+++ b/src/shell.mk
@@ -104,8 +104,6 @@
 #<
 ####################################################################################################
 
-⬛ :=
-
 define bmakelib.shell.error-if-nonzero
 $(eval bmakelib.shell.error-if-nonzero.__command := $(if $(1),$(1)$(if $(2),$(bmakelib.comma)$(2)$(if $(3),$(bmakelib.comma)$(3)$(if $(4),$(bmakelib.comma)$(4)$(if $(5),$(bmakelib.comma)$(5)$(if $(6),$(bmakelib.comma)$(6)$(if $(7),$(bmakelib.comma)$(7)$(if $(8),$(bmakelib.comma)$(8)$(if $(9),$(bmakelib.comma)$(9)$(if $(10),$(bmakelib.comma)$(10),),),),),),),),),),))$(⬛)$(if $(filter yes,$(bmakelib.conf.shell.error-if-nonzero.SILENT)),,$(info shell.error-if-nonzero: $(bmakelib.shell.error-if-nonzero.__command)))$(⬛)$(eval bmakelib.shell.error-if-nonzero.__result := $(shell $(bmakelib.shell.error-if-nonzero.__command)))$(⬛)$(if $(filter-out 0,$(.SHELLSTATUS)),$(error shell.error-if-nonzero: Command exited with non-zero value $(.SHELLSTATUS)),$(bmakelib.shell.error-if-nonzero.__result))
 endef

--- a/src/shell.mk
+++ b/src/shell.mk
@@ -25,10 +25,10 @@
 #   Makefile:
 #
 #	```Makefile
-#        VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)
+#	VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)
 #
-#        some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero, echo Hello, world)
-#        some-target :
+#	some-target : VAR2 := $(call bmakelib.shell.error-if-nonzero, echo Hello, world)
+#	some-target :
 #		@echo Unreachable recipe ⛔
 #	```
 #
@@ -94,7 +94,7 @@
 #   * Quad-quote all the variables and structures that are supposed to be only understood by shell.
 #     For example:
 #     - `$(call bmakelib.shell.error-if-nonzero,echo $$$$HOSTNAME)`
-#     - `$(call bmakelib.shell.error-if-nonzero,PATH="/usr/local/foo/bin:$$$$PATH" foo $$$$(date))
+#     - `$(call bmakelib.shell.error-if-nonzero,PATH="/usr/local/foo/bin:$$$$PATH" foo $$$$(date))`
 #
 #   * Currently the a command can contain upto **9** comma (,) charaters.
 #     - This number is totally arbitrary and it can be increased if there's need for it.

--- a/tests/test_shell.error-if-nonzero
+++ b/tests/test_shell.error-if-nonzero
@@ -128,10 +128,78 @@ EOF
 }
 
 ####################################################################################################
+# It should process commands containing comma (,) followed by whitespace
+####################################################################################################
+
+function command_with_comma_followed_by_whitespace {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+.PHONY : echo-vars
+
+VAR1 := \$(call bmakelib.shell.error-if-nonzero,\
+                echo field1,field2,field3 | cut -d, -f 2)
+
+some-target :
+	@echo \$(VAR1)
+EOF
+
+  make some-target > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+field2
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# It should fail make with an error message if the given command fails with a non-zero value.
+####################################################################################################
+
+function failing_command_should_make_with_error_message {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+.PHONY : echo-vars
+
+VAR1 := \$(call bmakelib.shell.error-if-nonzero,\
+                echo This should fail && false)
+
+some-target :
+	@echo \$(VAR1)
+EOF
+
+  make some-target > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+.+\*\*\*\s+shell.error-if-nonzero: Command exited with non-zero value 1.\s+Stop.
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
 
 test_cases=( command_with_commas \
                command_with_pipe_and_chain \
-               command_with_ampersand )
+               command_with_ampersand \
+               command_with_comma_followed_by_whitespace \
+               failing_command_should_make_with_error_message )
 
 test_case_name=''	# mutated in the for loop
 test_suite_status=0	# mutated in the for loop

--- a/tests/test_shell.error-if-nonzero
+++ b/tests/test_shell.error-if-nonzero
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+####################################################################################################
+# Copyright © 2023 Bahman Movaqar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+####################################################################################################
+
+set -o pipefail
+
+test_suite_name=$(basename $BASH_SOURCE)
+source ${root_dir}tests/lib.sh
+
+####################################################################################################
+# It should process commands containing up to commas
+####################################################################################################
+
+function command_with_commas {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+.PHONY : echo-var1
+
+VAR1 := \$(call bmakelib.shell.error-if-nonzero,echo p1,p2,p3,p4,p5,p6,p7,p8,p9)
+some-target :
+	@echo \$(VAR1)
+EOF
+
+  make some-target > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+p1,p2,p3,p4,p5,p6,p7,p8,p9
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# It should process commands containing pipe and chain operators
+####################################################################################################
+
+function command_with_pipe_and_chain {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+.PHONY : echo-vars
+
+VAR1 := \$(call bmakelib.shell.error-if-nonzero,\
+                bash --version | head -n 1)
+
+VAR2 := \$(call bmakelib.shell.error-if-nonzero,\
+                make --version | grep -q 'GNU Make 4'\
+                && echo Make 4.x || echo Not Make 4.x)
+some-target :
+	@echo '\$(VAR1)'
+	@echo '\$(VAR2)'
+EOF
+
+  make some-target > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+GNU bash.*
+Make 4.*
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# It should process commands containing $ character (eg subshell)
+####################################################################################################
+
+function command_with_ampersand {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+.PHONY : echo-vars
+
+VAR1 := \$(call bmakelib.shell.error-if-nonzero,\
+                [[ ! -z \$$$$HOME ]] && echo HOME set || echo No HOME)
+
+VAR2 := \$(call bmakelib.shell.error-if-nonzero,\
+                [[ ! -z \$$$$(which make) ]] && echo Make in PATH || echo Make not in PATH)
+
+some-target :
+	@echo \$(VAR1)
+	@echo \$(VAR2)
+EOF
+
+  make some-target > $actual_value_filename 2>&1
+
+  local expected_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expected_pattern_filename
+make.+Entering.+
+HOME set
+Make in PATH
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expected_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+
+test_cases=( command_with_commas \
+               command_with_pipe_and_chain \
+               command_with_ampersand )
+
+test_case_name=''	# mutated in the for loop
+test_suite_status=0	# mutated in the for loop
+for test_case in ${test_cases[@]}; do
+  test_case_name=$test_case
+  if ! bmakelib.test.run_test_case $test_case; then
+    test_suite_status=1
+  fi
+done
+
+exit $test_suite_status


### PR DESCRIPTION
Implement a `$(shell)` alternative which automatically causes the make process to abort in case the given command exits w/ a non-zero value.

Example:

Makefile:

```Makefile
VAR1 := $(call bmakelib.shell.error-if-nonzero, echo Kaboom! 💣 && false)

some-target :
	@echo Unreachable recipe ⛔
```

Shell:

```text
$ make some-target
Makefile:4: *** bmakelib.shell.error-if-nonzero: Command exited with non-zero value 1.  Stop.
```

---

:books: Full docs can be viewed at https://github.com/bahmanm/bmakelib/blob/95-implement-a-fail-fast-%24shell/doc/shell.md