### PR TITLE
`enum` features should be usable as `call`able variables

### DIFF
--- a/doc/enum.md
+++ b/doc/enum.md
@@ -5,28 +5,42 @@ Defines an enum (aka variant or option.)
 It can later be used to verify the value of variables by using
 `bmakelib.enum.error-unless-member`.
 
+There are two variations to this feature.
+- as a target dependency
+- as a variable (macro)
+
+Both produce the same results.  Except some minor cases, choice of the variation is mostly a
+matter of style.
+
 ### Example 1
 
-Makefile:
+Makefile using target dependency:
 
 ```Makefile
 define-enums : bmakelib.enum.define( DaysOfWeek/SUN,MON,TUE,WED,THU,FRI,SAT )
-define-enums : bmakelib.enum.define( DISTRO/openSUSE,Debian,Fedora)
+define-enums : bmakelib.enum.define( DISTRO/openSUSE,Debian,Fedora )
 include define-enums
 ```
 
-The above makefile defines two enums:
+Or Makefile using variable (macro):
+
+```Makefile
+$(call bmakelib.enum.define,DaysOfWeek/SUN,MON,TUE,WED,THU,FRI,SAT)
+$(call bmakelib.enum.define,DISTRO/openSUSE,Debian,Fedora)
+```
+
+Either of the above makefiles defines two enums:
 
 - `DaysOfWeek` with 7 possible values: `SUN`, `MON`, ...
 - `DISTRO` with 3 possible values: `openSUSE`, `Debian` and `Fedora`
 
-💡 _Note the last line in the snippet:  `include`ing a non-PHONY target causes it to be
+💡 _Note the last line in the first snippet:  `include`ing a non-PHONY target causes it to be
 evaluated before any other targets.  We're using this technic to ensure the enums are defined
 before we access them._
 
 ### Example 2
 
-Makefile:
+Makefile using target dependency:
 
 ```Makefile
 publish-package : bmakelib.enum.define( PKG-TYPE/deb,rpm,aur)
@@ -34,10 +48,17 @@ publish-package :
 	...
 ```
 
-The above snippet defines an enum `PKG-TYPE` with 3 possible values `deb`, `rpm` and `aur`.
+Or Makefile using variable (macro):
 
-_The difference with the method used in example 1 is that `PKG-TYPE` would not be accessible
-before `publish-package` is invoked._
+```Makefile
+$(call bmakelib.enum.define,PKG-TYPE/deb,rpm,aur)
+```
+
+Either of the above snippets defines an enum `PKG-TYPE` with 3 possible values `deb`, `rpm`
+and `aur`.
+
+_In case of the the first snippet (using target dependency), the difference with the method used
+in example 1 is that `PKG-TYPE` would not be accessible before `publish-package` is invoked._
 
 ---
 
@@ -45,13 +66,14 @@ before `publish-package` is invoked._
 
 Verifies if a variable's value is a member of a given enum and aborts make in case it's not.
 
-### Example
+_Note that just like `bmakelib.enum.define`, there are two variations of `error-unless-member`._
+
+### Example 1
 
 Makefile:
 
 ```Makefile
-define-enum : bmakelib.enum.define( DEPLOY-ENV/development,staging,production )
-include define-enum
+$(call bmakelib.enum.define,DEPLOY-ENV/development,staging,production)
 
 deploy : bmakelib.enum.error-unless-member( DEPLOY-ENV,ENV )
 deploy :
@@ -66,6 +88,29 @@ $ make ENV=local-laptop deploy
 
 $ make ENV=production deploy
 🚀 Deploying to production...
+```
+
+### Example 2
+
+Makefile:
+
+```Makefile
+define-enum : bmakelib.enum.define( BUILD-TARGET/android,ios,linux )
+include define-enum
+
+deploy :
+	$(call bmakelib.enum.error-unless-member,BUILD-TARGET,TARGET)
+	@echo 🏭 Building for $(TARGET)...
+```
+
+Shell:
+
+```text
+$ make TARGET=windows deploy
+*** 'windows' is not a member of enum 'BUILD-TARGET'.  Stop.
+
+$ make TARGET=ios deploy
+🏭 building for ios...
 ```
 
 ---

--- a/doc/enum.md
+++ b/doc/enum.md
@@ -43,7 +43,7 @@ before we access them._
 Makefile using target dependency:
 
 ```Makefile
-publish-package : bmakelib.enum.define( PKG-TYPE/deb,rpm,aur)
+publish-package : bmakelib.enum.define( PKG-TYPE/deb,rpm,aur )
 publish-package :
 	...
 ```

--- a/src/enum.mk
+++ b/src/enum.mk
@@ -15,35 +15,49 @@
 
 ####################################################################################################
 #>
-#   # `bmakelib.enum.define(%)`
+#   # `bmakelib.enum.define`
 #
 #   Defines an enum (aka variant or option.)
 #
 #   It can later be used to verify the value of variables by using
 #   `bmakelib.enum.error-unless-member`.
 #
+#   There are two variations to this feature.
+#   - as a target dependency
+#   - as a variable (macro)
+#
+#   Both produce the same results.  Except some minor cases, choice of the variation is mostly a
+#   matter of style.
+#
 #   ### Example 1
 #
-#   Makefile:
+#   Makefile using target dependency:
 #
 #	```Makefile
 #	define-enums : bmakelib.enum.define( DaysOfWeek/SUN,MON,TUE,WED,THU,FRI,SAT )
-#	define-enums : bmakelib.enum.define( DISTRO/openSUSE,Debian,Fedora)
+#	define-enums : bmakelib.enum.define( DISTRO/openSUSE,Debian,Fedora )
 #	include define-enums
 #	```
 #
-#   The above makefile defines two enums:
+#   Or Makefile using variable (macro):
+#
+#	```Makefile
+#	$(call bmakelib.enum.define,DaysOfWeek/SUN,MON,TUE,WED,THU,FRI,SAT)
+#	$(call bmakelib.enum.define,DISTRO/openSUSE,Debian,Fedora)
+#	```
+#
+#   Either of the above makefiles defines two enums:
 #
 #   - `DaysOfWeek` with 7 possible values: `SUN`, `MON`, ...
 #   - `DISTRO` with 3 possible values: `openSUSE`, `Debian` and `Fedora`
 #
-#   💡 _Note the last line in the snippet:  `include`ing a non-PHONY target causes it to be
+#   💡 _Note the last line in the first snippet:  `include`ing a non-PHONY target causes it to be
 #   evaluated before any other targets.  We're using this technic to ensure the enums are defined
 #   before we access them._
 #
 #   ### Example 2
 #
-#   Makefile:
+#   Makefile using target dependency:
 #
 #	```Makefile
 #	publish-package : bmakelib.enum.define( PKG-TYPE/deb,rpm,aur)
@@ -51,10 +65,17 @@
 #		...
 #	```
 #
-#   The above snippet defines an enum `PKG-TYPE` with 3 possible values `deb`, `rpm` and `aur`.
+#   Or Makefile using variable (macro):
 #
-#   _The difference with the method used in example 1 is that `PKG-TYPE` would not be accessible
-#   before `publish-package` is invoked._
+#	```Makefile
+#	$(call bmakelib.enum.define,PKG-TYPE/deb,rpm,aur)
+#	```
+#
+#   Either of the above snippets defines an enum `PKG-TYPE` with 3 possible values `deb`, `rpm`
+#   and `aur`.
+#
+#   _In case of the the first snippet (using target dependency), the difference with the method used
+#   in example 1 is that `PKG-TYPE` would not be accessible before `publish-package` is invoked._
 #<
 ####################################################################################################
 
@@ -64,12 +85,6 @@ bmakelib.enum.define(%) :
 		$(eval __enum_members_with_comma := $(word 2,$(subst $(bmakelib.slash),$(bmakelib.space),$(*)))) \
 		$(eval __enum_members := $(subst $(bmakelib.comma),$(bmakelib.space),$(__enum_members_with_comma))) \
 		$(eval __enum_$(__enum_name) := $(__enum_members)))
-
-####################################################################################################
-#>
-#   # `bmakelib.enum.define`
-#<
-####################################################################################################
 
 define bmakelib.enum.define
 $(eval \
@@ -84,13 +99,14 @@ endef
 #
 #   Verifies if a variable's value is a member of a given enum and aborts make in case it's not.
 #
-#   ### Example
+#   _Note that just like `bmakelib.enum.define`, there are two variations of `error-unless-member`._
+#
+#   ### Example 1
 #
 #   Makefile:
 #
 #	```Makefile
-#	define-enum : bmakelib.enum.define( DEPLOY-ENV/development,staging,production )
-#	include define-enum
+#	$(call bmakelib.enum.define,DEPLOY-ENV/development,staging,production)
 #
 #	deploy : bmakelib.enum.error-unless-member( DEPLOY-ENV,ENV )
 #	deploy :
@@ -106,6 +122,29 @@ endef
 #	$ make ENV=production deploy
 #	🚀 Deploying to production...
 #	```
+#
+#   ### Example 2
+#
+#   Makefile:
+#
+#	```Makefile
+#	define-enum : bmakelib.enum.define( BUILD-TARGET/android,ios,linux )
+#	include define-enum
+#
+#	deploy :
+#		$(call bmakelib.enum.error-unless-member,BUILD-TARGET,TARGET)
+#		@echo 🏭 Building for $(TARGET)...
+#	```
+#
+#   Shell:
+#
+#	```text
+#	$ make TARGET=windows deploy
+#	*** 'windows' is not a member of enum 'BUILD-TARGET'.  Stop.
+#
+#	$ make TARGET=ios deploy
+#	🏭 building for ios...
+#	```
 #<
 ####################################################################################################
 
@@ -116,12 +155,6 @@ bmakelib.enum.error-unless-member(%) :
 		$(if $(filter $($(__var_name)),$(__enum_$(__enum_name))),\
 			,\
 			$(error '$($(__var_name))' is not a member of enum '$(__enum_name)')))
-
-####################################################################################################
-#>
-#    # `bmakelib.enum.error-unless-member`
-#<
-####################################################################################################
 
 define bmakelib.enum.error-unless-member
 $(eval \

--- a/src/enum.mk
+++ b/src/enum.mk
@@ -60,7 +60,7 @@
 #   Makefile using target dependency:
 #
 #	```Makefile
-#	publish-package : bmakelib.enum.define( PKG-TYPE/deb,rpm,aur)
+#	publish-package : bmakelib.enum.define( PKG-TYPE/deb,rpm,aur )
 #	publish-package :
 #		...
 #	```

--- a/src/enum.mk
+++ b/src/enum.mk
@@ -15,7 +15,7 @@
 
 ####################################################################################################
 #>
-#   # `bmakelib.enum.define`
+#   # `bmakelib.enum.define(%)`
 #
 #   Defines an enum (aka variant or option.)
 #
@@ -67,6 +67,19 @@ bmakelib.enum.define(%) :
 
 ####################################################################################################
 #>
+#   # `bmakelib.enum.define`
+#<
+####################################################################################################
+
+define bmakelib.enum.define
+$(eval \
+	$(eval __enum_name := $(word 1,$(subst $(bmakelib.slash),$(bmakelib.space),$(1)))) \
+	$(eval __enum_members := $(word 2,$(subst $(bmakelib.slash),$(bmakelib.space),$(1))) $(2) $(3) $(4) $(5) $(6) $(7) $(8) $(9) $(10)) \
+	$(eval __enum_$(__enum_name) := $(__enum_members)))
+endef
+
+####################################################################################################
+#>
 #   # `bmakelib.enum.error-unless-member`
 #
 #   Verifies if a variable's value is a member of a given enum and aborts make in case it's not.
@@ -103,3 +116,16 @@ bmakelib.enum.error-unless-member(%) :
 		$(if $(filter $($(__var_name)),$(__enum_$(__enum_name))),\
 			,\
 			$(error '$($(__var_name))' is not a member of enum '$(__enum_name)')))
+
+####################################################################################################
+#>
+#    # `bmakelib.enum.error-unless-member`
+#<
+####################################################################################################
+
+define bmakelib.enum.error-unless-member
+$(eval \
+	$(if $(filter $($(2)),$(__enum_$(1))),\
+		,\
+		$(error '$($(2))' is not a member of enum '$(1)')))
+endef

--- a/tests/test_enum
+++ b/tests/test_enum
@@ -231,13 +231,48 @@ EOF
 }
 
 ####################################################################################################
+# Define the enum via target dependency but verify the value via macro
+####################################################################################################
+
+function when_enum_is_defined_via_target_verify_member_via_macro {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+\$(call bmakelib.enum.define,ENUM1/v1,v2)
+
+VAR1 ?=
+
+.PHONY : verify-member
+verify-member :
+	\$(call bmakelib.enum.error-unless-member,ENUM1,VAR1)
+	@echo \$(VAR1)
+EOF
+
+  make VAR1=v1 verify-member > $actual_value_filename 2>&1
+
+  local expexted_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expexted_pattern_filename
+make.+Entering.+
+v1
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expexted_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
 
 test_cases=( when_variable_value_is_a_member_of_the_enum
              when_variable_value_is_not_a_member_of_the_enum
              when_more_than_one_enum_and_variable_values_are_members_of_enums
              when_more_than_one_enum_and_one_variable_value_not_members_of_enum
              when_enum_is_defined_via_macro_verify_member_via_macro
-             when_enum_is_defined_via_macro_verify_member_via_target )
+             when_enum_is_defined_via_macro_verify_member_via_target
+             when_enum_is_defined_via_target_verify_member_via_macro )
 
 test_case_name=''	# mutated in the for loop
 test_suite_status=0	# mutated in the for loop

--- a/tests/test_enum
+++ b/tests/test_enum
@@ -21,7 +21,7 @@ test_suite_name=$(basename $BASH_SOURCE)
 source ${root_dir}tests/lib.sh
 
 ####################################################################################################
-# when the variable value is a member of the enum
+# When the variable value is a member of the enum
 ####################################################################################################
 
 function when_variable_value_is_a_member_of_the_enum {
@@ -55,7 +55,7 @@ EOF
 }
 
 ####################################################################################################
-# when the variable value is not a member of the enum
+# When the variable value is not a member of the enum
 ####################################################################################################
 
 function when_variable_value_is_not_a_member_of_the_enum {
@@ -89,7 +89,7 @@ EOF
 }
 
 ####################################################################################################
-# when there are multiple enums and all values are members of given enums
+# When there are multiple enums and all values are members of given enums
 ####################################################################################################
 
 function when_more_than_one_enum_and_variable_values_are_members_of_enums {
@@ -126,7 +126,7 @@ EOF
 }
 
 ####################################################################################################
-# when there are multiple enums and at least one of the values is not a member of the given enum
+# When there are multiple enums and at least one of the values is not a member of the given enum
 ####################################################################################################
 
 function when_more_than_one_enum_and_one_variable_value_not_members_of_enum {
@@ -163,11 +163,81 @@ EOF
 }
 
 ####################################################################################################
+# Use macros to define an enum and verify member
+####################################################################################################
+
+function when_enum_is_defined_via_macro_verify_member_via_macro {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+\$(call bmakelib.enum.define,ENUM1/v1,v2)
+
+VAR1 ?=
+
+\$(call bmakelib.enum.error-unless-member,ENUM1,VAR1)
+
+.PHONY : echo-member
+echo-member :
+	@echo \$(VAR1)
+EOF
+
+  make VAR1=v1 echo-member > $actual_value_filename 2>&1
+
+  local expexted_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expexted_pattern_filename
+make.+Entering.+
+v1
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expexted_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
+# Use macros to define an enum but use the target to verify the member
+####################################################################################################
+
+function when_enum_is_defined_via_macro_verify_member_via_target {
+  local test_case_name=${FUNCNAME[0]}
+  local actual_value_filename=${test_case_name}.actual.log
+  bmakelib.test.cat <<EOF > Makefile
+SHELL := /usr/bin/env bash
+include \$(bmakelib.ROOT)/bmakelib.mk
+
+\$(call bmakelib.enum.define,ENUM1/v1,v2)
+
+VAR1 ?=
+
+.PHONY : echo-member
+echo-member : bmakelib.enum.error-unless-member( ENUM1,VAR1 )
+	@echo \$(VAR1)
+EOF
+
+  make VAR1=v1 echo-member > $actual_value_filename 2>&1
+
+  local expexted_pattern_filename=${test_case_name}.expected.pattern
+  bmakelib.test.cat <<EOF > $expexted_pattern_filename
+make.+Entering.+
+v1
+make.+Leaving.+
+EOF
+
+  bmakelib.test.assert_matches $test_case_name $actual_value_filename $expexted_pattern_filename \
+    || return 1
+}
+
+####################################################################################################
 
 test_cases=( when_variable_value_is_a_member_of_the_enum
              when_variable_value_is_not_a_member_of_the_enum
              when_more_than_one_enum_and_variable_values_are_members_of_enums
-             when_more_than_one_enum_and_one_variable_value_not_members_of_enum )
+             when_more_than_one_enum_and_one_variable_value_not_members_of_enum
+             when_enum_is_defined_via_macro_verify_member_via_macro
+             when_enum_is_defined_via_macro_verify_member_via_target )
 
 test_case_name=''	# mutated in the for loop
 test_suite_status=0	# mutated in the for loop


### PR DESCRIPTION
RE #101 

---

As explained in the PR, the approach I took is to hard-code the number of parameters to both `define` and `error-unless-member` to 10.