### PR TITLE
Disable CircleCI Mac executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ workflows:
   test:
     jobs:
       - test_linux
-      - test_mac
+      # - test_mac
   release:
     jobs:
       - release:


### PR DESCRIPTION
The executor freezes during the boot up of the environment breaking the pipeline.